### PR TITLE
Added support to unzip mods for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Features
 * Download mods from the workshop (developed for Arma 3 but should work for any workshop colletion)
 * Create lowercase and no whitespace mod folders (for Linux compatibility)
-* Linux only: Extract the mods and remove the zip files
+* Extract the mods and remove the zip files
 * Mod updating
 
 ### Prerequisites

--- a/dlmods.py
+++ b/dlmods.py
@@ -180,13 +180,17 @@ for key, value in linksnames.items():
             if len(toextract) == 1:
                 subprocess.run(["unzip", toextract[0]])
                 subprocess.run(["rm", "-r", toextract[0]])
-        # else:
-        #   for fname in os.listdir(download_dir):
-        #       if fname.endswith('.zip') or fname.endswith('.rar'):
-        #           filename = fname
-        #   archivepath = download_dir + "\\" + filename
-        #   unpack_archive(archivepath)
-        #   os.remove(archivepath)
+        else:
+            for fname in os.listdir(download_dir):
+                if fname.endswith('.zip'):
+                    format = "zip"
+                    filename = fname
+                elif fname.endswith('.rar'):
+                    format = "rar"
+                    filename = fname
+            archivepath = download_dir + "\\" + filename
+            unpack_archive(archivepath, download_dir, format)
+            os.remove(archivepath)
 
     print("\n Downloaded {} of {} mods..\n \n".format
           (for_progress_tracking.index(value) + 1, len(linksnames)))


### PR DESCRIPTION
With this pull request the zip folders on windows are also unzipped like it works in linux.
This changes the behavior of the script. 
If wished I could disable this per deafult and enable with a argument or interactive question, but I think that it is more intuive if the script works the same in Linux and Windows.